### PR TITLE
Fix the incorrect installation of Hadoop during the Docker image build process

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,20 +8,24 @@ ENV HADOOP_VERSION=3.3.1
 # download and install hadoop
 RUN mkdir -p /opt && \
     cd /opt && \
-    curl http://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | \
-        tar -zx hadoop-${HADOOP_VERSION}/lib/native && \
+    curl -fSL http://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz -o hadoop.tar.gz && \
+    tar -xzf hadoop.tar.gz && \
     ln -s hadoop-${HADOOP_VERSION} hadoop && \
-    echo Hadoop ${HADOOP_VERSION} native libraries installed in /opt/hadoop/lib/native
+    rm hadoop.tar.gz && \
+    echo "Hadoop ${HADOOP_VERSION} installed in /opt/hadoop"
 
 # download and install spark
 RUN mkdir -p /opt && \
     cd /opt && \
-    curl http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz | \
-        tar -zx && \
+    curl -fSL http://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz -o spark.tgz && \
+    tar -xzf spark.tgz && \
     ln -s spark-${SPARK_VERSION}-bin-hadoop2.7 spark && \
-    echo Spark ${SPARK_VERSION} installed in /opt
+    rm spark.tgz && \
+    echo "Spark ${SPARK_VERSION} installed in /opt/spark"
 
 # add scripts and update spark default config
 ADD common.sh spark-master spark-worker /
 ADD spark-defaults.conf /opt/spark/conf/spark-defaults.conf
+
+# update PATH
 ENV PATH $PATH:/opt/spark/bin


### PR DESCRIPTION
…d process.

- Updated the RUN command to properly download and install Hadoop:

```dockerfile
RUN mkdir -p /opt && \
    cd /opt && \
    curl -fSL http://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz -o hadoop.tar.gz && \
    tar -xzf hadoop.tar.gz && \
    ln -s hadoop-${HADOOP_VERSION} hadoop && \
    rm hadoop.tar.gz && \
    echo "Hadoop ${HADOOP_VERSION} installed in /opt/hadoop"